### PR TITLE
fix module export

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ function getBit (v, idx) {
  * Exports
  */
 
-export default {
+export {
   createBv,
   setBit,
   clearBit,


### PR DESCRIPTION
Hello, it is me again :)

When trying to build deku with rollup, it has flagged an issue with import / export between bit-vector and dift. If in dift you have named imports:

``` javascript
import {createBv, setBit, getBit} from 'bit-vector'
```

Then you need named exports in bit-vector (instead of exporting a default object):

``` javascript
export {
  createBv,
  setBit,
  clearBit,
  getBit
}
```

I also took the opportunity to also npmignore .babelrc which I discovered today is best practice.
